### PR TITLE
Add delete.php to remove customers and contacts

### DIFF
--- a/delete.php
+++ b/delete.php
@@ -1,0 +1,38 @@
+<?php
+require_once "db.php";
+
+// Slett kunde
+if (isset($_GET['id'])) {
+    $kunde_id = intval($_GET['id']);
+
+    // Slett kontaktpersoner knyttet til kunden først
+    $sql = "DELETE FROM kontaktpersoner WHERE kunde_id = $kunde_id";
+    $conn->query($sql);
+
+    // Slett kunden
+    $sql = "DELETE FROM kunder WHERE kunde_id = $kunde_id";
+    if ($conn->query($sql) === TRUE) {
+        header("Location: index.php?msg=kunde_slettet");
+    } else {
+        header("Location: index.php?error=" . urlencode($conn->error));
+    }
+    exit();
+}
+
+// Slett kontaktperson
+if (isset($_GET['kontakt_id'])) {
+    $kontakt_id = intval($_GET['kontakt_id']);
+
+    $sql = "DELETE FROM kontaktpersoner WHERE kontakt_id = $kontakt_id";
+    if ($conn->query($sql) === TRUE) {
+        header("Location: index.php?msg=kontakt_slettet");
+    } else {
+        header("Location: index.php?error=" . urlencode($conn->error));
+    }
+    exit();
+}
+
+// Hvis ingenting ble sendt — gå tilbake
+header("Location: index.php");
+exit();
+?>

--- a/index.php
+++ b/index.php
@@ -64,7 +64,7 @@ require_once "config.php";
                                 <td>
                                     <form method='GET' action='delete.php'>
                                         <input type='hidden' name='id' value='" . $row['kunde_id'] . "'>
-                                        <button type='submit'>Slett</button>
+                                        <button type='submit' onclick=\"return confirm('Er du sikker på at du vil slette denne kunden?')\">Slett</button>
                                     </form>
                                 </td>
                                 <td>
@@ -155,7 +155,7 @@ require_once "config.php";
                                 <td>
                                     <form method='GET' action='delete.php'>
                                         <input type='hidden' name='kontakt_id' value='" . $row['kontakt_id'] . "'>
-                                        <button type='submit'>Slett</button>
+                                        <button type='submit' onclick=\"return confirm('Er du sikker på at du vil slette denne kontaktpersonen?')\">Slett</button>
                                     </form>
                                 </td>
                                 <td>


### PR DESCRIPTION
Add delete.php which requires db.php and handles deletions via GET parameters: 'id' deletes a customer and its related kontaktpersoner (contacts), and 'kontakt_id' deletes a single contact. Queries run and the script redirects back to index.php with success or error messages. Uses intval() for basic sanitization; consider using prepared statements and CSRF protection for safety.